### PR TITLE
Enhancement: Handle 'STS' Course Codes by Setting 'Seat No' as 'Seat …

### DIFF
--- a/src/vtop_handler/parsers/parse_exam_schedule.py
+++ b/src/vtop_handler/parsers/parse_exam_schedule.py
@@ -21,6 +21,9 @@ def get_exam_row_data(row):
     }
     #  connvert  NaN to None
     data = {k: None if pd.isna(v) else v for k, v in data.items()}
+     # Check if "Course Code" starts with "STS" and set "Seat Location" as "Seat No" 
+    if data["Course Code"].startswith("STS"):
+        data["Seat Location"] = data["Seat No"]
     return data
 
 def parse_exam_schedule(exam_schedule_html: str) -> Dict:


### PR DESCRIPTION

If the "Course Code" starts with "STS" in the exam schedule data. When the course code meets this condition, the "Seat No" field is now set as the "Seat Location" to ensure that the app does include Seat No  because until now its not shown for the STS Exam